### PR TITLE
Fix for YDN V201809

### DIFF
--- a/lib/shampoohat/version.rb
+++ b/lib/shampoohat/version.rb
@@ -21,6 +21,6 @@
 
 module Shampoohat
   module ApiConfig
-    CLIENT_LIB_VERSION = '0.0.8.pre1'
+    CLIENT_LIB_VERSION = '0.0.8'
   end
 end

--- a/lib/shampoohat/version.rb
+++ b/lib/shampoohat/version.rb
@@ -21,6 +21,6 @@
 
 module Shampoohat
   module ApiConfig
-    CLIENT_LIB_VERSION = '0.0.7'
+    CLIENT_LIB_VERSION = '0.0.8.pre1'
   end
 end


### PR DESCRIPTION
## YDN V201809での変更点
- 以下のように、(V201806まではあった)`lang`が入力パラメータから消えた

https://github.com/yahoojp-marketing/ydn-api-documents/blob/201809/wsdl/ReportDefinitionService.wsdl#L307

- それによって、パラメータの数が同じになるため

```
[1] pry(#<Shampoohat::ParametersValidator>)> args
=> [{:report_category=>"AD"}]
[2] pry(#<Shampoohat::ParametersValidator>)> in_params
=> [{:name=>:report_category, :type=>"ReportCategory", :min_occurs=>1, :max_occurs=>1}]
```

- ` result.merge({in_param[:name] => deep_copy(args[index])})` によって入れ子構造にしてしまう

```
[3] pry(#<Shampoohat::ParametersValidator>)> args_hash
=> {:report_category=>{:report_category=>"AD"}}
```

- しかし、YDN V201809が期待しているのは、入れ子ではないフラットな構造

## 今回の改修
- `if in_params.size != args.size || FLATTEN_KEYS.include?(in_param[:name])` 条件を追加することにより、`FLATTEN_KEYS`を持つ`in_params`は直接展開するようにする

```ruby
    def validate_args(action_name, args)
      in_params = @registry.get_method_signature(action_name)[:input]
      args_hash = in_params.each_with_index.inject({}) do |result, (in_param, index)|
        # NOTE : Yahoo APIの場合、次のケースでは、入れ子構造にしない
        # - パラメータの数が異なる場合
        # - パラメータの数は同じでも、予め指定したnameをもつ場合
        if in_params.size != args.size || FLATTEN_KEYS.include?(in_param[:name])
          result.merge({in_param[:name] => args[0][in_param[:name]]})
        else
          result.merge({in_param[:name] => deep_copy(args[index])})
        end
      end
      validate_arguments(args_hash, in_params)
      return args_hash
    end
```

```
[1] pry(#<Shampoohat::ParametersValidator>)> in_params
=> [{:name=>:report_category, :type=>"ReportCategory", :min_occurs=>1, :max_occurs=>1}]
[2] pry(#<Shampoohat::ParametersValidator>)> args
=> [{:report_category=>"AD"}]
```

```
[3] pry(#<Shampoohat::ParametersValidator>)> args_hash
=> {:report_category=>"AD"}
```
