### PR TITLE
Fix for YSS 201901

### DIFF
--- a/lib/shampoohat/parameters_validator.rb
+++ b/lib/shampoohat/parameters_validator.rb
@@ -24,7 +24,7 @@ module Shampoohat
   class ParametersValidator
     # Savon special keys.
     IGNORED_HASH_KEYS = [:order!, :attributes!]
-    FLATTEN_KEYS = %i[report_category].freeze
+    FLATTEN_KEYS = %i[report_category report_type].freeze
 
     # We collect required namespaces into this hash during validation.
     attr_reader :extra_namespaces

--- a/lib/shampoohat/version.rb
+++ b/lib/shampoohat/version.rb
@@ -21,6 +21,6 @@
 
 module Shampoohat
   module ApiConfig
-    CLIENT_LIB_VERSION = '0.0.8'
+    CLIENT_LIB_VERSION = '0.0.9'
   end
 end


### PR DESCRIPTION
## やったこと
- #3 と同様に `lang` パラメータが消えたことによる対応をYSSのレポート定義に対しても適用する

[sponsored-search-api-documents/ReportDefinitionService.md at 201901 · yahoojp-marketing/sponsored-search-api-documents](https://github.com/yahoojp-marketing/sponsored-search-api-documents/blob/201901/docs/ja/api_reference/services/ReportDefinitionService.md#getreportfields)